### PR TITLE
Adds SQL Pack

### DIFF
--- a/src/lua/community.lua
+++ b/src/lua/community.lua
@@ -5,6 +5,7 @@
 ---@type LazySpec
 return {
   "AstroNvim/astrocommunity",
+  -- NOTE: SQL defined in plugins/sqlfluff.lua
   { import = "astrocommunity.pack.lua" },
   { import = "astrocommunity.pack.nix" },
   { import = "astrocommunity.pack.python.base" },

--- a/src/lua/plugins/sqlfluff.lua
+++ b/src/lua/plugins/sqlfluff.lua
@@ -1,11 +1,42 @@
 return {
-  -- keep the community pack
-  { import = "astrocommunity.pack.sql" },
+  -- Treesitter SQL parser
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sql" })
+    end,
+  },
 
-  -- none-ls (null-ls fork): make diagnostics/formatting use postgres
+  -- Install sqls via mason
+  {
+    "mason-org/mason-lspconfig.nvim",
+    optional = true,
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sqls" })
+    end,
+  },
+
+  -- Configure sqls LSP (no nanotee/sqls.nvim needed)
+  {
+    "AstroNvim/astrolsp",
+    opts = {
+      config = {
+        sqls = {
+          on_attach = function(client, _)
+            client.server_capabilities.documentFormattingProvider = false
+            client.server_capabilities.documentRangeFormattingProvider = false
+          end,
+        },
+      },
+    },
+  },
+
+  -- sqlfluff: postgres dialect
   {
     "jay-babu/mason-null-ls.nvim",
+    optional = true,
     opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, { "sqlfluff" })
       opts.handlers = opts.handlers or {}
       opts.handlers.sqlfluff = function()
         local null_ls = require "null-ls"
@@ -19,9 +50,10 @@ return {
     end,
   },
 
-  -- Conform: also switch formatter args to postgres
+  -- Conform: postgres formatter
   {
     "stevearc/conform.nvim",
+    optional = true,
     opts = {
       formatters_by_ft = { sql = { "sqlfluff" } },
       formatters = {


### PR DESCRIPTION
Community pack uses require("sqls") but the dependency of
nanotee/sqls.nvim doesn't have an init.lua and therefore cannot be
imported that way. Somehow these two things slipped out of sync. There's
nothing too special going on in nanotee/sqls.nvim anyway so this self
contained version is good enough.